### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,8 @@ setup(name='snapception',
 	  install_requires=[
 	  	'requests',
 	  	'click',
-	  	'mitmproxy'
+	  	'mitmproxy',
+		'command_line'
 	  ],
 	  include_package_data=True,
 	  entry_points={'console_scripts' : ['snapception=snapception.command_line:launch']}


### PR DESCRIPTION
Fix the "import command_line" error when trying to launch snapception after installing it using 
 pip3 install snapception